### PR TITLE
workaround for jdom bug (https://github.com/dom4j/dom4j/issues/99)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,16 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'org.dom4j:dom4j:2.1.3'
+    implementation('org.dom4j:dom4j:2.1.3') {
+        // workaround for jdom2 bug (https://github.com/dom4j/dom4j/issues/99)
+        // NOTE: a component metadata rule will not solve the problem for library consumers - this is the only way
+        exclude module: 'pull-parser'
+        exclude module: 'jaxen'
+        exclude module: 'xpp3'
+        exclude module: 'xsdlib'
+        exclude module: 'stax-api'
+        exclude module: 'jaxb-api'
+    }
     implementation 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.slf4j:jcl-over-slf4j:1.7.32'


### PR DESCRIPTION
library consumers using Gradle 6+ will have issues with JAXB resolution, causing confusing errors in their applications